### PR TITLE
Added feature to remove data for current day from 5 day forecast API

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -193,6 +193,10 @@ function displayForecast(averageData) {
 
     var forecastCards = $(".user-city-forecast");
     Object.keys(averageData).forEach((day, index) => {
+        if (index == 0)
+        {
+            return; //Skips the first set of data which represents data for the current day
+        }
         var card = `
             <div class="col">
                 <div class="card bg-secondary text-light">


### PR DESCRIPTION
Sometimes the 5-day forecast API gives data for the next 5 days including the current day. Other times it provides data for the next 5 full days. Right now, the API is giving the data for the current day, so to remove the data for the current day, we use an if statement and if the index is 0 we return (go to the next iteration of the function)